### PR TITLE
Mocker api responsen til joark og dpiverksett med wiremock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,6 +313,15 @@ services:
     ports:
       - 8090:8080
 
+  wiremock:
+    image: wiremock/wiremock:3.3.1
+    command:
+      - -global-response-templating
+    volumes:
+      - ./mock-req-res/mappings:/home/wiremock/mappings
+    ports:
+      - 8091:8080
+
 volumes:
   postgres-vedtak-data: #
   postgres-meldekort-data: #

--- a/mock-req-res/mappings/dpiverksett-res.json
+++ b/mock-req-res/mappings/dpiverksett-res.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "urlPath": "/api/iverksetting",
+    "method": "POST",
+    "headers": {
+      "Accept": {
+        "contains": "json"
+      }
+    },
+    "bodyPatterns" : [{
+      "equalToJson" : {
+        "sakId": "${json-unit.any-string}",
+        "behandlingId": "${json-unit.any-string}",
+        "personident": "${json-unit.any-string}",
+        "vedtak": {
+          "vedtakstype": "${json-unit.any-string}",
+          "vedtakstidspunkt": "${json-unit.any-string}",
+          "resultat": "${json-unit.any-string}",
+          "saksbehandlerId": "${json-unit.any-string}",
+          "beslutterId": "${json-unit.any-string}",
+          "utbetalinger": "${json-unit.ignore}",
+          "vedtaksperioder": "${json-unit.ignore}"
+        },
+        "forrigeIverksetting": "${json-unit.ignore}"
+      }
+    }]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {}
+  }
+}

--- a/mock-req-res/mappings/joark-req-res.json
+++ b/mock-req-res/mappings/joark-req-res.json
@@ -1,0 +1,62 @@
+{
+  "request": {
+    "urlPath": "/rest/journalpostapi/v1/journalpost",
+    "method": "POST",
+    "headers": {
+      "Accept": {
+        "contains": "json"
+      }
+    },
+    "queryParameters": {
+      "forsoekFerdigstill": {
+          "or": [
+            {"equalTo":  "true"},
+            {"equalTo":  "false"}
+          ]
+        }
+      },
+    "bodyPatterns" : [{
+      "equalToJson" : {
+        "tittel": "${json-unit.any-string}",
+        "journalpostType": "${json-unit.any-string}",
+        "tema": "${json-unit.any-string}",
+        "kanal": "${json-unit.any-string}",
+        "journalfoerendeEnhet": "${json-unit.any-string}",
+        "avsenderMottaker": {
+          "id": "${json-unit.any-string}",
+          "idType": "${json-unit.any-string}"
+        },
+        "bruker": {
+          "id": "${json-unit.any-string}",
+          "idType": "${json-unit.any-string}"
+        },
+        "sak": "${json-unit.ignore}",
+        "dokumenter": [
+          {
+            "tittel": "${json-unit.any-string}",
+            "brevkode": "${json-unit.any-string}",
+            "dokumentvarianter": [
+              {
+                "filtype": "${json-unit.any-string}",
+                "variantformat": "${json-unit.any-string}",
+                "filnavn": "${json-unit.any-string}"
+              },
+              {
+                "filtype": "${json-unit.any-string}",
+                "variantformat": "${json-unit.any-string}",
+                "filnavn": "${json-unit.any-string}"
+              }
+            ]
+          }
+        ],
+        "eksternReferanseId": "${json-unit.any-string}"
+      }
+    }]
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "journalpostId": "journalpostId"
+    }
+  }
+}


### PR DESCRIPTION
I denne PRen setter vi opp wiremock så kan vi kjøre de eksterne tjenester lokalt og motta mock responsen.

I denne PRen har vi mocket responsen til joark og dpiverksett tjenestene. 